### PR TITLE
Add basic auth support

### DIFF
--- a/check_elasticsearch_cluster.pl
+++ b/check_elasticsearch_cluster.pl
@@ -154,7 +154,7 @@ sub check_each($$$$$) {
   my %statuses;
   my ($what, $where, $warning, $critical, $message) = @_;
   # Run check_threshold on everything
-  foreach my $k (keys $what) {
+  foreach my $k (keys %$what) {
     my $current_key = $where->($what->{$k});
     if (ref $warning eq "CODE") {
       $warning = $warning->($what->{$k});

--- a/check_elasticsearch_node.pl
+++ b/check_elasticsearch_node.pl
@@ -183,7 +183,7 @@ sub check_each($$$$$) {
   my %statuses;
   my ($what, $where, $warning, $critical, $message) = @_;
   # Run check_threshold on everything
-  foreach my $k (keys $what) {
+  foreach my $k (keys %$what) {
     my $current_key = $where->($what->{$k});
     if (ref $warning eq "CODE") {
       $warning = $warning->($what->{$k});
@@ -224,10 +224,10 @@ if ($np->opts->get('open-fds')) {
   $critical = clean_extra_chars($critical);
   $critical = convert_to_decimal($critical);
 
-  my $open_fds = $json->{nodes}->{(keys $json->{nodes})[0]}->{process}->{open_file_descriptors};
+  my $open_fds = $json->{nodes}->{(keys %{$json->{nodes}})[0]}->{process}->{open_file_descriptors};
   # Get the default number of open file descriptors
   $json = get_json("/_nodes/_local?pretty");
-  my $open_fds_max = $json->{nodes}->{(keys $json->{nodes})[0]}->{process}->{max_file_descriptors};
+  my $open_fds_max = $json->{nodes}->{(keys %{$json->{nodes}})[0]}->{process}->{max_file_descriptors};
 
   $code = $np->check_threshold(
     check => $open_fds,
@@ -252,7 +252,7 @@ elsif ($np->opts->get('jvm-heap-usage')) {
   $warning = clean_extra_chars($warning);
   $critical = clean_extra_chars($critical);
 
-  my $jvm_heap_used = $json->{nodes}->{(keys $json->{nodes})[0]}->{jvm}->{mem}->{heap_used_percent};
+  my $jvm_heap_used = $json->{nodes}->{(keys %{$json->{nodes}})[0]}->{jvm}->{mem}->{heap_used_percent};
 
   $code = $np->check_threshold(
     check => $jvm_heap_used,
@@ -273,7 +273,7 @@ elsif ($np->opts->get('thread-pool-rejected')) {
   $warning = $warning || '@1:';
   $critical = $critical || '@5:';
 
-  my $thread_pool = $json->{nodes}->{(keys $json->{nodes})[0]}->{thread_pool};
+  my $thread_pool = $json->{nodes}->{(keys %{$json->{nodes}})[0]}->{thread_pool};
 
   check_each($thread_pool, sub {
       my ($f) = @_;
@@ -296,7 +296,7 @@ elsif ($np->opts->get('breakers-tripped')) {
   $warning = $warning || '@1:';
   $critical = $critical || '@5:';
 
-  my $breakers = $json->{nodes}->{(keys $json->{nodes})[0]}->{breakers};
+  my $breakers = $json->{nodes}->{(keys %{$json->{nodes}})[0]}->{breakers};
 
   check_each($breakers, sub {
       my ($f) = @_;
@@ -318,7 +318,7 @@ elsif ($np->opts->get('breakers-size')) {
   $warning = $warning || '@75%:';
   $critical = $critical || '@85%:';
 
-  my $breakers = $json->{nodes}->{(keys $json->{nodes})[0]}->{breakers};
+  my $breakers = $json->{nodes}->{(keys %{$json->{nodes}})[0]}->{breakers};
 
   check_each($breakers, sub {
       my ($f) = @_;

--- a/check_elasticsearch_node.pl
+++ b/check_elasticsearch_node.pl
@@ -97,6 +97,16 @@ $np->add_arg(
   default => 'http://localhost:9200',
 );
 
+$np->add_arg(spec => 'username|user|u=s',
+    help => "Username for authentication",
+    default => "",
+);
+
+$np->add_arg(spec => 'password|p=s',
+    help => "Password for authentication",
+    default => ""
+);
+
 $np->getopts;
 
 sub clean_extra_chars($) {
@@ -123,7 +133,15 @@ sub get_json($) {
   # NRPE timeout is 10 seconds, give us 1 second to run
   $ua->timeout($np->opts->timeout-1);
   $url = $np->opts->url.$url;
-  my $response = $ua->get($url);
+
+  my $req = HTTP::Request->new(GET => $url);
+
+  # Username and Password are defined for basic auth
+  if ($np->opts->username and $np->opts->password) {
+    $req->authorization_basic($np->opts->username, $np->opts->password); 
+  }
+
+  my $response = $ua->request($req);
 
   if (!$response->is_success) {
     $np->nagios_exit(CRITICAL, $response->status_line);


### PR DESCRIPTION
When using ES behind shield or authenticated reverse proxy (nginx, apache, etc.) we need to provide credentials for authentication.

This PR:
- Adds basic authentication support
- Removes `keys on reference is experimental at` warnings introduced since **Perl 5.14**. See this [comment](http://stackoverflow.com/a/29614053) for more details.
