### PR TITLE
Do not overwrite variables

### DIFF
--- a/check_elasticsearch_cluster.pl
+++ b/check_elasticsearch_cluster.pl
@@ -148,6 +148,17 @@ sub check_status($$) {
   $np->add_message($code, $_[1]);
 }
 
+sub get_threshold_value {
+  my ($thresh, $value, $key) = @_;
+
+  if (ref $thresh eq 'CODE') {
+    return $thresh->($value, $key);
+  }
+  else {
+    return $thresh;
+  }
+}
+
 # Check a data structure with check_threshold.
 # TODO Make sure it works recursively
 sub check_each($$$$$) {
@@ -155,19 +166,10 @@ sub check_each($$$$$) {
   my ($what, $where, $warning, $critical, $message) = @_;
   # Run check_threshold on everything
   foreach my $k (keys %$what) {
-    my ($warn, $crit);
     my $current_key = $where->($what->{$k});
 
-    if (ref $warning eq "CODE") {
-      $warn = $warning->($what->{$k});
-    } else {
-      $warn = $warning;
-    }
-    if (ref $critical eq "CODE") {
-      $crit = $critical->($what->{$k});
-    } else {
-      $crit = $critical;
-    }
+    my $warn = get_threshold_value($warning, $what->{$k}, $k);
+    my $crit = get_threshold_value($critical, $what->{$k}, $k);
 
     my $code = $np->check_threshold(
       check => $current_key,

--- a/check_elasticsearch_cluster.pl
+++ b/check_elasticsearch_cluster.pl
@@ -155,18 +155,24 @@ sub check_each($$$$$) {
   my ($what, $where, $warning, $critical, $message) = @_;
   # Run check_threshold on everything
   foreach my $k (keys %$what) {
+    my ($warn, $crit);
     my $current_key = $where->($what->{$k});
+
     if (ref $warning eq "CODE") {
-      $warning = $warning->($what->{$k});
+      $warn = $warning->($what->{$k});
+    } else {
+      $warn = $warning;
     }
     if (ref $critical eq "CODE") {
-      $critical = $critical->($what->{$k});
+      $crit = $critical->($what->{$k});
+    } else {
+      $crit = $critical;
     }
 
     my $code = $np->check_threshold(
       check => $current_key,
-      warning => $warning,
-      critical => $critical,
+      warning => $warn,
+      critical => $crit,
     );
 
     # and put in in a hash where the status is the key and the value an array

--- a/check_elasticsearch_node.pl
+++ b/check_elasticsearch_node.pl
@@ -178,6 +178,14 @@ sub pretty_join($) {
   } @$a);
 }
 
+sub get_threshold_value {
+    return $thresh->($value, $key);
+  }
+  else {
+    return $thresh;
+  }
+}
+
 # Check a data structure with check_threshold.
 # TODO Make sure it works recursively
 sub check_each($$$$$) {
@@ -186,18 +194,9 @@ sub check_each($$$$$) {
   # Run check_threshold on everything
   foreach my $k (keys %$what) {
     my $current_key = $where->($what->{$k});
-    my ($warn, $crit);
 
-    if (ref $warning eq "CODE") {
-      $warn = $warning->($what->{$k}, $k);
-    } else {
-      $warn = $warning;
-    }
-    if (ref $critical eq "CODE") {
-      $crit = $critical->($what->{$k}, $k);
-    } else {
-      $crit = $critical;
-    }
+    my $warn = get_threshold_value($warning, $what->{$k}, $k);
+    my $crit = get_threshold_value($critical, $what->{$k}, $k);
 
     my $code = $np->check_threshold(
       check => $current_key,

--- a/check_elasticsearch_node.pl
+++ b/check_elasticsearch_node.pl
@@ -187,14 +187,17 @@ sub check_each($$$$$) {
   foreach my $k (keys %$what) {
     my $current_key = $where->($what->{$k});
     my ($warn, $crit);
+
     if (ref $warning eq "CODE") {
       $warn = $warning->($what->{$k}, $k);
+    } else {
+      $warn = $warning;
     }
     if (ref $critical eq "CODE") {
       $crit = $critical->($what->{$k}, $k);
+    } else {
+      $crit = $critical;
     }
-    $warn ||= $warning;
-    $crit ||= $critical;
 
     my $code = $np->check_threshold(
       check => $current_key,


### PR DESCRIPTION
$warning and $critical were being replaced, which is undesirable.
That block is structurally repeated, so it should probably become a function or
macro.

check_elasticsearch_cluster has been simplified to use an else clause.